### PR TITLE
Change port to 8443 for BE target group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_alb_listener" "buildengine" {
 // Create BuildEngine Target Group
 resource "aws_alb_target_group" "buildengine" {
   name                 = replace("tg-buildengine-${var.app_env}", "/(.{0,32})(.*)/", "$1")
-  port                 = "80"
+  port                 = "8443"
   protocol             = "HTTP"
   vpc_id               = module.vpc.id
   deregistration_delay = "30"

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,6 @@ resource "aws_security_group" "db_access_limited_ips" {
   description = "Allow MySQL traffic from limited IPs"
   vpc_id      = module.vpc.id
 }
-
 resource "aws_security_group_rule" "mysql" {
   count             = var.db_access_enabled == "true" ? 1 : 0
   type              = "ingress"
@@ -40,26 +39,28 @@ resource "aws_security_group_rule" "postgres" {
   cidr_blocks       = var.db_access_ips
 }
 
-// Create database and root password
-resource "random_id" "buildengine_db_root_pass" {
+// Create database and root passwords
+resource "random_id" "db_admin_root_pass" {
   byte_length = 16
 }
 
-// Create DB
-module "rds" {
-  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=7.2.0"
-  app_name                = var.app_name
-  app_env                 = var.app_env
-  db_name                 = var.buildengine_db_name
-  db_root_user            = var.buildengine_db_root_user
-  db_root_pass            = random_id.buildengine_db_root_pass.hex
-  subnet_group_name       = module.vpc.db_subnet_group_name
-  availability_zone       = var.aws_zones[0]
-  security_groups         = [module.vpc.vpc_default_sg_id, aws_security_group.db_access_limited_ips.id]
-  backup_retention_period = var.db_backup_retention_period
-  multi_az                = var.db_multi_az
+// Create shared RDS instance for BuildEngine and Portal (if deployed)
+resource "aws_db_instance" "db_instance" {
+  engine                  = "postgres"
+  engine_version          = "17.8"
+  port                    = 5432
+  identifier              = "${var.app_name}-${var.app_env}"
   instance_class          = var.db_instance_class
-  publicly_accessible     = "true"
+  allocated_storage       = var.db_storage
+  backup_retention_period = var.db_backup_retention_period
+  publicly_accessible     = true
+  multi_az                = var.db_multi_az
+  db_name                 = var.buildengine_db_name
+  username                = var.db_admin_root_user
+  password                = random_id.db_admin_root_pass.hex
+  vpc_security_group_ids  = [module.vpc.vpc_default_sg_id, aws_security_group.db_access_limited_ips.id]
+  db_subnet_group_name    = module.vpc.db_subnet_group_name
+  availability_zone       = var.aws_zones[0]
 }
 
 // Determine most recent ECS optimized AMI
@@ -891,16 +892,13 @@ module "ecsservice_buildengine" {
   service_name       = "buildengine"
   service_env        = var.app_env
   container_def_json = templatefile("${path.module}/task-def-buildengine.json", {
-    api_cpu                              = var.buildengine_api_cpu
-    api_memory                           = var.buildengine_api_memory
-    cron_cpu                             = var.buildengine_cron_cpu
-    cron_memory                          = var.buildengine_cron_memory
+    buildengine_cpu                      = var.buildengine_cpu
+    buildengine_memory                   = var.buildengine_memory
     buildengine_docker_image             = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.buildengine_docker_image}"
     buildengine_docker_tag               = var.buildengine_docker_tag
-    ADMIN_EMAIL                          = var.admin_email
     API_ACCESS_TOKEN                     = random_id.api_access_token.hex
-    API_BASE_URL                         = var.buildengine_api_base_url
     APP_ENV                              = var.app_env
+    AUTH0_SECRET                         = var.deploy_portal ? random_id.auth0_secret[0].hex : var.scriptoria_auth0_secret
     AWS_ACCESS_KEY_ID                    = aws_iam_access_key.buildengine.id
     AWS_SECRET_ACCESS_KEY                = aws_iam_access_key.buildengine.secret
     AWS_USER_ID                          = var.aws_account_id
@@ -910,21 +908,21 @@ module "ecsservice_buildengine" {
     BUILD_ENGINE_SECRETS_BUCKET          = aws_s3_bucket.secrets.bucket
     CODE_BUILD_IMAGE_REPO                = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.buildagent_code_build_image_repo}-${var.app_env}"
     CODE_BUILD_IMAGE_TAG                 = var.buildagent_code_build_image_tag
-    FRONT_COOKIE_KEY                     = random_id.front_cookie_key.hex
-    LOGENTRIES_KEY                       = var.logentries_key
-    MAILER_PASSWORD                      = var.mailer_password
-    MAILER_USEFILES                      = var.mailer_usefiles
-    MAILER_USERNAME                      = var.mailer_username
-    MYSQL_DATABASE                       = var.buildengine_db_name
-    MYSQL_HOST                           = module.rds.address
-    MYSQL_PASSWORD                       = random_id.buildengine_db_root_pass.hex
-    MYSQL_USER                           = var.buildengine_db_root_user
+    DATABASE_URL                         = "postgres://${var.db_admin_root_user}:${random_id.db_admin_root_pass.hex}@${aws_db_instance.db_instance.address}/${var.buildengine_db_name}?schema=public"
+    HONEYCOMB_API_KEY                    = var.honeycomb_api_key
+    ORIGIN                               = "https://${var.app_sub_domain}-buildengine.${var.cloudflare_domain}:8443"
+    otel_cpu                             = var.otel_cpu
+    otel_memory                          = var.otel_memory
+    otel_docker_image                    = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.otel_docker_image}"
+    otel_docker_tag                      = var.otel_docker_tag
+    PUBLIC_SCRIPTORIA_URL                = var.deploy_portal ? "https://${var.app_sub_domain}.${var.cloudflare_domain}" : var.scriptoria_url
     SCRIPTURE_EARTH_KEY                  = var.scripture_earth_key
+    VALKEY_HOST                          = aws_elasticache_replication_group.valkey[0].primary_endpoint_address
   })
   desired_count      = 1
   tg_arn             = aws_alb_target_group.buildengine.arn
-  lb_container_name  = "web"
-  lb_container_port  = 80
+  lb_container_name  = "buildengine"
+  lb_container_port  = 8443
   ecsServiceRole_arn = module.ecscluster.ecsServiceRole_arn
 }
 
@@ -975,34 +973,9 @@ resource "aws_iam_user_policy_attachment" "appbuilder-portal-email" {
   policy_arn = aws_iam_policy.email-notification[0].arn
 }
 
-resource "random_id" "portal_db_root_pass" {
-  count       = var.deploy_portal ? 1 : 0
-  byte_length = 16
-}
-
-module "portal_db" {
-  count                   = var.deploy_portal ? 1 : 0
-  source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=7.2.0"
-  engine                  = "postgres"
-  engine_version          = "17.8"
-  app_name                = "${var.app_name}-portal"
-  app_env                 = var.app_env
-  db_name                 = var.portal_db_name
-  db_root_user            = var.portal_db_root_user
-  db_root_pass            = random_id.portal_db_root_pass[0].hex
-  subnet_group_name       = module.vpc.db_subnet_group_name
-  availability_zone       = var.aws_zones[0]
-  security_groups         = [module.vpc.vpc_default_sg_id, aws_security_group.db_access_limited_ips.id]
-  allocated_storage       = var.db_storage
-  backup_retention_period = var.db_backup_retention_period
-  multi_az                = var.db_multi_az
-  instance_class          = var.db_instance_class
-  publicly_accessible     = "true"
-}
-
 // Create security group for Valkey access
 resource "aws_security_group" "valkey_access" {
-  count       = var.deploy_portal ? 1 : 0
+  count       = 1 // With BE2, it is always needed
   name        = "valkey-access-${var.app_env}"
   description = "Allow Valkey traffic from application"
   vpc_id      = module.vpc.id
@@ -1031,14 +1004,14 @@ resource "aws_security_group" "valkey_access" {
 
 // Create Valkey subnet group
 resource "aws_elasticache_subnet_group" "valkey" {
-  count      = var.deploy_portal ? 1 : 0
+  count      = 1  // With BE2, it is always needed
   name       = "valkey-subnet-group-${var.app_env}"
   subnet_ids = module.vpc.public_subnet_ids
 }
 
 // Create Valkey parameter group with noeviction policy
 resource "aws_elasticache_parameter_group" "valkey" {
-  count  = var.deploy_portal ? 1 : 0
+  count  = 1  // With BE2, it is always needed
   name   = "valkey-params-${var.app_env}"
   family = "redis7"
 
@@ -1050,7 +1023,7 @@ resource "aws_elasticache_parameter_group" "valkey" {
 
 // Create Valkey replication group (uses Valkey engine in ElastiCache)
 resource "aws_elasticache_replication_group" "valkey" {
-  count                         = var.deploy_portal ? 1 : 0
+  count                         = 1  // With BE2, it is always needed
   replication_group_id          = "valkey-${var.app_env}"
   description                   = "Valkey (Redis-compatible) cache for ${var.app_env}"
   engine                        = "redis"
@@ -1096,7 +1069,7 @@ module "ecsservice_portal" {
     AWS_EMAIL_ACCESS_KEY_ID                    = aws_iam_access_key.portal[0].id
     AWS_EMAIL_SECRET_ACCESS_KEY                = aws_iam_access_key.portal[0].secret
     AWS_REGION                                 = var.aws_region
-    DATABASE_URL                               = "postgres://${var.portal_db_root_user}:${random_id.portal_db_root_pass[0].hex}@${module.portal_db[0].address}/${var.portal_db_name}?schema=public"
+    DATABASE_URL                               = "postgres://${var.db_admin_root_user}:${random_id.db_admin_root_pass.hex}@${aws_db_instance.db_instance.address}/${var.portal_db_name}?schema=public"
     DEFAULT_BUILDENGINE_URL                    = "https://${cloudflare_record.buildengine.hostname}:8443"
     DEFAULT_BUILDENGINE_API_ACCESS_TOKEN       = random_id.api_access_token.hex
     MAIL_SENDER                                = var.mail_sender

--- a/main.tf
+++ b/main.tf
@@ -896,6 +896,8 @@ module "ecsservice_buildengine" {
     buildengine_memory                   = var.buildengine_memory
     buildengine_docker_image             = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.buildengine_docker_image}"
     buildengine_docker_tag               = var.buildengine_docker_tag
+    buildengine_otel_docker_image        = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${var.buildengine_otel_docker_image}"
+    buildengine_otel_docker_tag          = var.buildengine_otel_docker_tag
     API_ACCESS_TOKEN                     = random_id.api_access_token.hex
     APP_ENV                              = var.app_env
     AUTH0_SECRET                         = var.deploy_portal ? random_id.auth0_secret[0].hex : var.scriptoria_auth0_secret

--- a/main.tf
+++ b/main.tf
@@ -984,7 +984,7 @@ module "portal_db" {
   count                   = var.deploy_portal ? 1 : 0
   source                  = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=7.2.0"
   engine                  = "postgres"
-  engine_version          = "14.17"
+  engine_version          = "17.8"
   app_name                = "${var.app_name}-portal"
   app_env                 = var.app_env
   db_name                 = var.portal_db_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,27 +30,18 @@ output "buildengine_secret_access_key" {
 }
 
 output "buildengine_db_address" {
-  value = module.rds.address
+  value = aws_db_instance.db_instance.address
 }
 
-output "buildengine_db_root_pass" {
-  value = random_id.buildengine_db_root_pass.hex
+output "db_admin_username" {
+  value = var.db_admin_root_user
 }
-
-output "buildengine_db_username" {
-  value = var.buildengine_db_root_user
+output "db_admin_root_pass" {
+  value = random_id.db_admin_root_pass.hex
 }
 
 output "portal_db_address" {
-  value = var.deploy_portal ? module.portal_db[0].address : "Portal not deployed"
-}
-
-output "portal_db_root_pass" {
-  value = var.deploy_portal ? random_id.portal_db_root_pass[0].hex : "Portal not deployed"
-}
-
-output "portal_db_username" {
-  value = var.deploy_portal ? var.portal_db_root_user : "Portal not deployed"
+  value = var.deploy_portal ? aws_db_instance.db_instance.address : "Portal not deployed"
 }
 
 #output "user_management_db_address" {
@@ -72,6 +63,13 @@ output "portal_email_id" {
 output "portal_email_secret" {
   value     = var.deploy_portal ? aws_iam_access_key.portal[0].secret : "Portal not deployed"
   sensitive = true
+}
+
+output "scriptoria_auth0_secret" {
+  value = var.deploy_portal ? random_id.auth0_secret[0].hex : var.scriptoria_auth0_secret
+}
+output "scriptoria_url" {
+  value = var.deploy_portal ? "https://${var.app_sub_domain}.${var.cloudflare_domain}" : var.scriptoria_url
 }
 
 output "valkey_address" {

--- a/task-def-buildengine.json
+++ b/task-def-buildengine.json
@@ -132,7 +132,7 @@
     ],
     "workingDirectory": null,
     "readonlyRootFilesystem": null,
-    "image": "${otel_docker_image}:${otel_docker_tag}",
+    "image": "${buildengine_otel_docker_image}:${buildengine_otel_docker_tag}",
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,

--- a/task-def-buildengine.json
+++ b/task-def-buildengine.json
@@ -1,8 +1,7 @@
 [
   {
     "volumesFrom": [],
-    "memory": ${api_memory
-    },
+    "memory": ${buildengine_memory},
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,
@@ -10,33 +9,29 @@
     "portMappings": [
       {
         "hostPort": 0,
-        "containerPort": 80,
+        "containerPort": 8443,
         "protocol": "tcp"
       }
-    ],
+    ],    
     "hostname": null,
     "essential": true,
     "entryPoint": [],
     "mountPoints": [],
-    "name": "web",
+    "name": "buildengine",
     "ulimits": null,
     "dockerSecurityOptions": null,
     "environment": [
-      {
-        "name": "ADMIN_EMAIL",
-        "value": "${ADMIN_EMAIL}"
-      },
       {
         "name": "API_ACCESS_TOKEN",
         "value": "${API_ACCESS_TOKEN}"
       },
       {
-        "name": "API_BASE_URL",
-        "value": "${API_BASE_URL}"
-      },
-      {
         "name": "APP_ENV",
         "value": "${APP_ENV}"
+      },
+      {
+        "name": "AUTH0_SECRET",
+        "value": "${AUTH0_SECRET}"
       },
       {
         "name": "AWS_ACCESS_KEY_ID",
@@ -75,173 +70,73 @@
         "value": "${CODE_BUILD_IMAGE_TAG}"
       },
       {
-        "name": "FRONT_COOKIE_KEY",
-        "value": "${FRONT_COOKIE_KEY}"
+        "name": "DATABASE_URL",
+        "value": "${DATABASE_URL}"
       },
       {
-        "name": "LOGENTRIES_KEY",
-        "value": "${LOGENTRIES_KEY}"
+        "name": "ORIGIN",
+        "value": "${ORIGIN}"
       },
       {
-        "name": "MAILER_PASSWORD",
-        "value": "${MAILER_PASSWORD}"
+        "name": "PUBLIC_SCRIPTORIA_URL",
+        "value": "${PUBLIC_SCRIPTORIA_URL}"
       },
       {
-        "name": "MAILER_USEFILES",
-        "value": "${MAILER_USEFILES}"
+        "name": "SCRIPTURE_EARTH_KEY",
+        "value": "${SCRIPTURE_EARTH_KEY}"
       },
       {
-        "name": "MAILER_USERNAME",
-        "value": "${MAILER_USERNAME}"
-      },
-      {
-        "name": "MYSQL_DATABASE",
-        "value": "${MYSQL_DATABASE}"
-      },
-      {
-        "name": "MYSQL_HOST",
-        "value": "${MYSQL_HOST}"
-      },
-      {
-        "name": "MYSQL_PASSWORD",
-        "value": "${MYSQL_PASSWORD}"
-      },
-      {
-        "name": "MYSQL_USER",
-        "value": "${MYSQL_USER}"
+        "name": "VALKEY_HOST",
+        "value": "${VALKEY_HOST}"
       }
     ],
-    "links": [],
     "workingDirectory": null,
     "readonlyRootFilesystem": null,
     "image": "${buildengine_docker_image}:${buildengine_docker_tag}",
-    "command": [],
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,
-    "cpu": ${api_cpu
-    },
+    "dependsOn": [
+      {
+        "containerName": "otel",
+        "condition": "START"
+      }
+    ],
+    "links": [
+      "otel"
+    ],
+    "cpu": ${buildengine_cpu},
     "privileged": null,
     "memoryReservation": null
   },
   {
     "volumesFrom": [],
-    "memory": ${cron_memory
-    },
+    "memory": ${otel_memory},
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,
     "dnsSearchDomains": null,
     "portMappings": [],
     "hostname": null,
-    "essential": true,
+    "essential": false,
     "entryPoint": [],
     "mountPoints": [],
-    "name": "cron",
+    "name": "otel",
     "ulimits": null,
     "dockerSecurityOptions": null,
     "environment": [
       {
-        "name": "ADMIN_EMAIL",
-        "value": "${ADMIN_EMAIL}"
-      },
-      {
-        "name": "API_ACCESS_TOKEN",
-        "value": "${API_ACCESS_TOKEN}"
-      },
-      {
-        "name": "APP_ENV",
-        "value": "${APP_ENV}"
-      },
-      {
-        "name": "AWS_ACCESS_KEY_ID",
-        "value": "${AWS_ACCESS_KEY_ID}"
-      },
-      {
-        "name": "AWS_SECRET_ACCESS_KEY",
-        "value": "${AWS_SECRET_ACCESS_KEY}"
-      },
-      {
-        "name": "AWS_USER_ID",
-        "value": "${AWS_USER_ID}"
-      },
-      {
-        "name": "BUILD_ENGINE_ARTIFACTS_BUCKET",
-        "value": "${BUILD_ENGINE_ARTIFACTS_BUCKET}"
-      },
-      {
-        "name": "BUILD_ENGINE_ARTIFACTS_BUCKET_REGION",
-        "value": "${BUILD_ENGINE_ARTIFACTS_BUCKET_REGION}"
-      },
-      {
-        "name": "BUILD_ENGINE_PROJECTS_BUCKET",
-        "value": "${BUILD_ENGINE_PROJECTS_BUCKET}"
-      },
-      {
-        "name": "BUILD_ENGINE_SECRETS_BUCKET",
-        "value": "${BUILD_ENGINE_SECRETS_BUCKET}"
-      },
-      {
-        "name": "CODE_BUILD_IMAGE_REPO",
-        "value": "${CODE_BUILD_IMAGE_REPO}"
-      },
-      {
-        "name": "CODE_BUILD_IMAGE_TAG",
-        "value": "${CODE_BUILD_IMAGE_TAG}"
-      },
-      {
-        "name": "FRONT_COOKIE_KEY",
-        "value": "${FRONT_COOKIE_KEY}"
-      },
-      {
-        "name": "LOGENTRIES_KEY",
-        "value": "${LOGENTRIES_KEY}"
-      },
-      {
-        "name": "MAILER_PASSWORD",
-        "value": "${MAILER_PASSWORD}"
-      },
-      {
-        "name": "MAILER_USEFILES",
-        "value": "${MAILER_USEFILES}"
-      },
-      {
-        "name": "MAILER_USERNAME",
-        "value": "${MAILER_USERNAME}"
-      },
-      {
-        "name": "MYSQL_DATABASE",
-        "value": "${MYSQL_DATABASE}"
-      },
-      {
-        "name": "MYSQL_HOST",
-        "value": "${MYSQL_HOST}"
-      },
-      {
-        "name": "MYSQL_PASSWORD",
-        "value": "${MYSQL_PASSWORD}"
-      },
-      {
-        "name": "MYSQL_USER",
-        "value": "${MYSQL_USER}"
-      },
-      {
-        "name": "SCRIPTURE_EARTH_KEY",
-        "value": "${SCRIPTURE_EARTH_KEY}"
+        "name": "HONEYCOMB_API_KEY",
+        "value": "${HONEYCOMB_API_KEY}"
       }
     ],
-    "links": [],
     "workingDirectory": null,
     "readonlyRootFilesystem": null,
-    "image": "${buildengine_docker_image}:${buildengine_docker_tag}",
-    "command": [
-      "/data/run-cron.sh"
-    ],
+    "image": "${otel_docker_image}:${otel_docker_tag}",
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,
-    "cpu": ${cron_cpu
-    },
+    "cpu": ${otel_cpu},
     "privileged": null,
     "memoryReservation": null
   }

--- a/task-def-portal.json
+++ b/task-def-portal.json
@@ -116,8 +116,7 @@
   },
   {
     "volumesFrom": [],
-    "memory": ${otel_memory
-    },
+    "memory": ${otel_memory},
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,
@@ -142,8 +141,7 @@
     "user": null,
     "dockerLabels": null,
     "logConfiguration": null,
-    "cpu": ${otel_cpu
-    },
+    "cpu": ${otel_cpu},
     "privileged": null,
     "memoryReservation": null
   }

--- a/task-def-portal.json
+++ b/task-def-portal.json
@@ -1,8 +1,7 @@
 [
   {
     "volumesFrom": [],
-    "memory": ${portal_memory
-    },
+    "memory": ${portal_memory},
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,

--- a/vars.tf
+++ b/vars.tf
@@ -92,28 +92,14 @@ variable "buildagent_code_build_image_tag" {
   default     = "latest"
 }
 
-variable "buildengine_api_base_url" {
-  type = string
-}
-
-variable "buildengine_api_cpu" {
+variable "buildengine_cpu" {
   type    = string
   default = "128"
 }
 
-variable "buildengine_api_memory" {
+variable "buildengine_memory" {
   type    = string
-  default = "128"
-}
-
-variable "buildengine_cron_cpu" {
-  type    = string
-  default = "128"
-}
-
-variable "buildengine_cron_memory" {
-  type    = string
-  default = "128"
+  default = "384"
 }
 
 variable "buildengine_db_name" {
@@ -136,11 +122,6 @@ variable "buildengine_docker_tag" {
   default = "production"
 }
 
-variable "buildengine_subdomain" {
-  type    = string
-  default = "buildengine"
-}
-
 variable "cert_domain_name" {
   type        = string
   description = "Full domain name on ACM certificate"
@@ -157,6 +138,12 @@ variable "cloudflare_email" {
 
 variable "cloudflare_token" {
   type = string
+}
+
+variable "db_admin_root_user" {
+  type        = string
+  default     = "appbuilder_admin"
+  description = "Master username for the shared PostgreSQL RDS instance"
 }
 
 variable "db_storage" {
@@ -187,11 +174,6 @@ variable "ec2_ssh_key_name" {
 variable "https_ips" {
   type        = list(string)
   description = "A list of IP address CIDR blocks for allowing https access"
-}
-
-variable "logentries_key" {
-  type    = string
-  default = ""
 }
 
 variable "mailer_password" {
@@ -239,7 +221,7 @@ variable "portal_docker_tag" {
 
 variable "portal_memory" {
   type    = string
-  default = "128"
+  default = "384"
 }
 
 variable "otel_cpu" {
@@ -269,6 +251,18 @@ variable "honeycomb_api_key" {
 variable "sparkpost_api_key" {
   type    = string
   default = ""
+}
+
+variable "scriptoria_auth0_secret" {
+  type = string
+  default = ""
+  description = "Set to scriptoria_auth0_secret output of Scriptoria deployment (for BuildEngine only deployments)"
+}
+
+variable "scriptoria_url" {
+  type = string
+  default = ""
+  description = "Set to scriptoria_url output of Scriptoria deployment (for BuildEngine only deployments)"
 }
 
 variable "scripture_earth_key" {

--- a/vars.tf
+++ b/vars.tf
@@ -122,6 +122,16 @@ variable "buildengine_docker_tag" {
   default = "production"
 }
 
+variable "buildengine_otel_docker_image" {
+  type = string
+  default = "appbuilder-buildengine-otel"
+}
+
+variable "buildengine_otel_docker_tag" {
+  type    = string
+  default = "production"
+}
+
 variable "cert_domain_name" {
   type        = string
   description = "Full domain name on ACM certificate"


### PR DESCRIPTION
This may fix the issues we've been running into with BE2 continuously restarting due to failing healthchecks.

The target group currently has 80 as the port to check.

The original BuildEngine definitions from before #4 had port 80 as an additional port in the container, presumably for the health check (?).