### PR TITLE
Change target-group port for BE to 8443

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_alb_listener" "buildengine" {
 // Create BuildEngine Target Group
 resource "aws_alb_target_group" "buildengine" {
   name                 = replace("tg-buildengine-${var.app_env}", "/(.{0,32})(.*)/", "$1")
-  port                 = "80"
+  port                 = "8443"
   protocol             = "HTTP"
   vpc_id               = module.vpc.id
   deregistration_delay = "30"


### PR DESCRIPTION
This may fix the issues we've been running into with BE2 continuously restarting due to failing healthchecks.

The target group currently has 80 as the port to check.

The original BuildEngine definitions from before #4 had port 80 as an additional port in the container, presumably for the health check (?).